### PR TITLE
feat: Orleans host and client

### DIFF
--- a/src/OrlyanChat.Grains/OrlyanChat.Grains.csproj
+++ b/src/OrlyanChat.Grains/OrlyanChat.Grains.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.6.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.6.2"/>
+    </ItemGroup>
+
+</Project>

--- a/src/OrlyanChat.Grains/RngGrain.cs
+++ b/src/OrlyanChat.Grains/RngGrain.cs
@@ -1,0 +1,22 @@
+﻿using Orleans;
+using Orleans.Concurrency;
+
+namespace OrlyanChat.Grains;
+
+public interface IRngGrain : IGrainWithGuidKey
+{
+    Task<int> GetSomeNumber();
+}
+
+[StatelessWorker]
+public sealed class RngGrain : Grain, IRngGrain
+{
+    private readonly Random rng = new(0xB00B);
+
+    public Task<int> GetSomeNumber()
+    {
+        var number = rng.Next();
+
+        return Task.FromResult(number);
+    }
+}

--- a/src/OrlyanChat.Host/OrlyanChat.Host.csproj
+++ b/src/OrlyanChat.Host/OrlyanChat.Host.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\OrlyanChat.Grains\OrlyanChat.Grains.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Orleans.Server" Version="3.6.2"/>
+    </ItemGroup>
+
+</Project>

--- a/src/OrlyanChat.Host/Program.cs
+++ b/src/OrlyanChat.Host/Program.cs
@@ -1,0 +1,22 @@
+﻿using System.Net;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using OrlyanChat.Grains;
+
+using var host = Host.CreateDefaultBuilder(args).UseOrleans(siloBuilder =>
+{
+    siloBuilder.UseLocalhostClustering().Configure<ClusterOptions>(opts =>
+    {
+        opts.ClusterId = "local-orlyanchat-cluster";
+        opts.ServiceId = "orlyanchat";
+    }).Configure<EndpointOptions>(opts =>
+    {
+        opts.GatewayPort = 30000;
+        opts.SiloPort = 11111;
+        opts.AdvertisedIPAddress = IPAddress.Loopback;
+    }).ConfigureApplicationParts(partman => { partman.AddApplicationPart(typeof(RngGrain).Assembly); });
+}).Build();
+
+await host.RunAsync();

--- a/src/OrlyanChat.Web.Api/Controllers/NumbersController.cs
+++ b/src/OrlyanChat.Web.Api/Controllers/NumbersController.cs
@@ -1,0 +1,26 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Mvc;
+using OrlyanChat.Web.Api.Services.Rng;
+
+namespace OrlyanChat.Web.Api.Controllers;
+
+[ApiController]
+[Produces(MediaTypeNames.Application.Json)]
+[Route("numbers")]
+public sealed class NumbersController : Controller
+{
+    private readonly IRngService rngService;
+
+    public NumbersController(IRngService rngService)
+    {
+        this.rngService = rngService ?? throw new ArgumentNullException(nameof(rngService));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetSomeNumber()
+    {
+        var someNumber = await rngService.GetSomeNumber();
+
+        return Ok(someNumber);
+    }
+}

--- a/src/OrlyanChat.Web.Api/OrlyanChat.Web.Api.csproj
+++ b/src/OrlyanChat.Web.Api/OrlyanChat.Web.Api.csproj
@@ -6,4 +6,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\OrlyanChat.Grains\OrlyanChat.Grains.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Orleans.Client" Version="3.6.2"/>
+    </ItemGroup>
+
 </Project>

--- a/src/OrlyanChat.Web.Api/Program.cs
+++ b/src/OrlyanChat.Web.Api/Program.cs
@@ -1,7 +1,21 @@
+using Orleans;
+using OrlyanChat.Web.Api.Services;
+using OrlyanChat.Web.Api.Services.Rng;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<OrleansClientHostedService>();
+
+builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<OrleansClientHostedService>());
+builder.Services.AddSingleton(sp => sp.GetRequiredService<OrleansClientHostedService>().Client);
+builder.Services.AddSingleton<IGrainFactory>(sp => sp.GetRequiredService<OrleansClientHostedService>().Client);
+
+builder.Services.AddMvc();
+
+builder.Services.AddTransient<IRngService, RngService>();
+
 var app = builder.Build();
 
-app.MapGet("/",
-    () => "Hello World!");
+app.MapControllers();
 
-app.Run();
+await app.RunAsync();

--- a/src/OrlyanChat.Web.Api/Properties/launchSettings.json
+++ b/src/OrlyanChat.Web.Api/Properties/launchSettings.json
@@ -1,25 +1,10 @@
 ﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:51803",
-      "sslPort": 44394
-    }
-  },
   "profiles": {
     "OrlyanChat.Web.Api": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7090;http://localhost:5188",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:65535",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/OrlyanChat.Web.Api/Services/OrleansClientHostedService.cs
+++ b/src/OrlyanChat.Web.Api/Services/OrleansClientHostedService.cs
@@ -1,0 +1,61 @@
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using OrlyanChat.Grains;
+
+namespace OrlyanChat.Web.Api.Services;
+
+public sealed class OrleansClientHostedService : IHostedService
+{
+    private const int MAX_CONNECTION_ATTEMPTS = 3;
+    private static readonly TimeSpan RETRY_DELAY = TimeSpan.FromSeconds(10);
+
+    public OrleansClientHostedService(ILoggerProvider applicationLoggerProvider)
+    {
+        if (applicationLoggerProvider is null)
+        {
+            throw new ArgumentNullException(nameof(applicationLoggerProvider));
+        }
+
+        Client = new ClientBuilder().UseLocalhostClustering(30000).Configure<ClusterOptions>(opts =>
+            {
+                opts.ClusterId = "local-orlyanchat-cluster";
+                opts.ServiceId = "orlyanchat";
+            }).ConfigureLogging(logging => { logging.AddProvider(applicationLoggerProvider); })
+            .ConfigureApplicationParts(partman => { partman.AddApplicationPart(typeof(RngGrain).Assembly); }).Build();
+    }
+
+    public IClusterClient Client { get; }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var connectionAttempts = 0;
+
+        async Task<bool> ConnectRetryLogic(Exception whatWentWrong)
+        {
+            if (connectionAttempts == MAX_CONNECTION_ATTEMPTS)
+            {
+                return false;
+            }
+
+            if (whatWentWrong is SiloUnavailableException)
+            {
+                connectionAttempts = connectionAttempts + 1;
+
+                await Task.Delay(RETRY_DELAY, cancellationToken);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        await Client.Connect(ConnectRetryLogic);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await Client.Close();
+        await Client.DisposeAsync();
+    }
+}

--- a/src/OrlyanChat.Web.Api/Services/Rng/IRngService.cs
+++ b/src/OrlyanChat.Web.Api/Services/Rng/IRngService.cs
@@ -1,0 +1,6 @@
+namespace OrlyanChat.Web.Api.Services.Rng;
+
+public interface IRngService
+{
+    Task<int> GetSomeNumber();
+}

--- a/src/OrlyanChat.Web.Api/Services/Rng/RngService.cs
+++ b/src/OrlyanChat.Web.Api/Services/Rng/RngService.cs
@@ -1,0 +1,23 @@
+using Orleans;
+using OrlyanChat.Grains;
+
+namespace OrlyanChat.Web.Api.Services.Rng;
+
+public sealed class RngService : IRngService
+{
+    private readonly IClusterClient clusterClient;
+
+    public RngService(IClusterClient clusterClient)
+    {
+        this.clusterClient = clusterClient ?? throw new ArgumentNullException(nameof(clusterClient));
+    }
+
+    public async Task<int> GetSomeNumber()
+    {
+        var rngGrain = clusterClient.GetGrain<IRngGrain>(Guid.Empty);
+
+        var number = await rngGrain.GetSomeNumber();
+
+        return number;
+    }
+}

--- a/src/OrlyanChat.Web.Api/appsettings.Development.json
+++ b/src/OrlyanChat.Web.Api/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/src/OrlyanChat.Web.Api/appsettings.json
+++ b/src/OrlyanChat.Web.Api/appsettings.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
-}

--- a/src/OrlyanChat.sln
+++ b/src/OrlyanChat.sln
@@ -2,6 +2,10 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrlyanChat.Web.Api", "OrlyanChat.Web.Api\OrlyanChat.Web.Api.csproj", "{DF233395-AD97-4FB1-81B0-832453BCA82A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrlyanChat.Grains", "OrlyanChat.Grains\OrlyanChat.Grains.csproj", "{33D4795D-B0DC-428B-9BD1-8FC83B5BD998}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrlyanChat.Host", "OrlyanChat.Host\OrlyanChat.Host.csproj", "{9B5DACE3-7646-4783-B59A-0345C5A959A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +16,13 @@ Global
 		{DF233395-AD97-4FB1-81B0-832453BCA82A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF233395-AD97-4FB1-81B0-832453BCA82A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF233395-AD97-4FB1-81B0-832453BCA82A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33D4795D-B0DC-428B-9BD1-8FC83B5BD998}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33D4795D-B0DC-428B-9BD1-8FC83B5BD998}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33D4795D-B0DC-428B-9BD1-8FC83B5BD998}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33D4795D-B0DC-428B-9BD1-8FC83B5BD998}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B5DACE3-7646-4783-B59A-0345C5A959A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B5DACE3-7646-4783-B59A-0345C5A959A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B5DACE3-7646-4783-B59A-0345C5A959A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B5DACE3-7646-4783-B59A-0345C5A959A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Added the Host for Orelans cluster as a separate .NET App using .NET Generic Host
Web.Api has been augmented with an Orleans client that calls the cluster
Sample grain was implemented and is called from the Web.Api client to showcase functionality